### PR TITLE
Add type hints and pre-commit tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.8
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy

--- a/OSINT_REGEX.py
+++ b/OSINT_REGEX.py
@@ -1,91 +1,95 @@
 import re
 
+
 class OSINTRegex:
-    def find_emails(self, text):
+    def find_emails(self, text: str) -> list[str]:
         """Return a list of email addresses found in the text."""
-        pattern = r'\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b'
+        pattern = r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b"
         return re.findall(pattern, text)
 
-    def find_websites(self, text):
+    def find_websites(self, text: str) -> list[str]:
         """Return a list of website URLs found in the text."""
-        pattern = r'\b(?:https?://)?(?:www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s]*)?\b'
+        pattern = (
+            r"\b(?:https?://)?(?:www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s]*)?\b"
+        )
         return re.findall(pattern, text)
 
-    def find_twitter_handles(self, text):
+    def find_twitter_handles(self, text: str) -> list[str]:
         """Return a list of Twitter handles (without @) found in the text."""
-        pattern = r'@([A-Za-z0-9_]{1,15})\b'
+        pattern = r"@([A-Za-z0-9_]{1,15})\b"
         return re.findall(pattern, text)
 
-    def find_btc_wallets(self, text):
+    def find_btc_wallets(self, text: str) -> list[str]:
         """Return a list of Bitcoin wallet addresses found in the text."""
-        pattern = r'\b(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}\b'
+        pattern = r"\b(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}\b"
         return re.findall(pattern, text)
 
-    def find_eth_wallets(self, text):
+    def find_eth_wallets(self, text: str) -> list[str]:
         """Return a list of Ethereum wallet addresses found in the text."""
-        pattern = r'\b0x[a-fA-F0-9]{40}\b'
+        pattern = r"\b0x[a-fA-F0-9]{40}\b"
         return re.findall(pattern, text)
 
-    def find_monero_wallets(self, text):
+    def find_monero_wallets(self, text: str) -> list[str]:
         """Return a list of Monero wallet addresses found in the text."""
-        pattern = r'\b[48][0-9AB][1-9A-HJ-NP-Za-km-z]{93}\b'
+        pattern = r"\b[48][0-9AB][1-9A-HJ-NP-Za-km-z]{93}\b"
         return re.findall(pattern, text)
 
-    def find_dash_wallets(self, text):
+    def find_dash_wallets(self, text: str) -> list[str]:
         """Return a list of Dash wallet addresses found in the text."""
-        pattern = r'\bX[1-9A-HJ-NP-Za-km-z]{33}\b'
+        pattern = r"\bX[1-9A-HJ-NP-Za-km-z]{33}\b"
         return re.findall(pattern, text)
 
-    def find_cardano_wallets(self, text):
+    def find_cardano_wallets(self, text: str) -> list[str]:
         """Return a list of Cardano wallet addresses found in the text."""
-        pattern = r'\baddr1[a-z0-9]+\b'
+        pattern = r"\baddr1[a-z0-9]+\b"
         return re.findall(pattern, text)
 
-    def find_doge_wallets(self, text):
+    def find_doge_wallets(self, text: str) -> list[str]:
         """Return a list of Dogecoin wallet addresses found in the text."""
-        pattern = r'\bD[a-zA-Z0-9_.-]{33}\b'
+        pattern = r"\bD[a-zA-Z0-9_.-]{33}\b"
         return re.findall(pattern, text)
 
-    def find_litecoin_wallets(self, text):
+    def find_litecoin_wallets(self, text: str) -> list[str]:
         """Return a list of Litecoin wallet addresses found in the text."""
-        pattern = r'\b[LM3][a-km-zA-HJ-NP-Z1-9]{26,33}\b'
+        pattern = r"\b[LM3][a-km-zA-HJ-NP-Z1-9]{26,33}\b"
         return re.findall(pattern, text)
 
-    def find_ripple_wallets(self, text):
+    def find_ripple_wallets(self, text: str) -> list[str]:
         """Return a list of Ripple wallet addresses found in the text."""
-        pattern = r'\br[0-9a-zA-Z]{33}\b'
+        pattern = r"\br[0-9a-zA-Z]{33}\b"
         return re.findall(pattern, text)
 
-    def find_stellar_wallets(self, text):
+    def find_stellar_wallets(self, text: str) -> list[str]:
         """Return a list of Stellar wallet addresses found in the text."""
-        pattern = r'\bG[0-9A-Z]{40,60}\b'
+        pattern = r"\bG[0-9A-Z]{40,60}\b"
         return re.findall(pattern, text)
 
-    def find_transaction_hashes(self, text):
+    def find_transaction_hashes(self, text: str) -> list[str]:
         """Return a list of 64-character transaction hashes found in the text."""
-        pattern = r'\b[a-fA-F0-9]{64}\b'
+        pattern = r"\b[a-fA-F0-9]{64}\b"
         return re.findall(pattern, text)
 
-    def find_prices(self, text):
+    def find_prices(self, text: str) -> list[str]:
         """Return a list of price expressions (USD, EUR, €, $) found in the text."""
         pattern = (
-            r'((USD|EUR|€|\$)\s?(\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2}))|'
-            r'(\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2})?)\s?(USD|EUR|€|\$))'
+            r"((USD|EUR|€|\$)\s?(\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2}))|"
+            r"(\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{2})?)\s?(USD|EUR|€|\$))"
         )
         return [match[0] for match in re.findall(pattern, text)]
 
-    def find_latlon(self, text):
+    def find_latlon(self, text: str) -> list[tuple[str, str]]:
         """Return a list of (lat, lon) tuples found in the text."""
         pattern = (
-            r'(?<!\d)([-+]?(?:[1-8]?\d(?:\.\d+)?|90(?:\.0+)?))\s*,\s*'
-            r'([-+]?(?:180(?:\.0+)?|(?:1[0-7]\d|[1-9]?\d)(?:\.\d+)?))(?!\d)'
+            r"(?<!\d)([-+]?(?:[1-8]?\d(?:\.\d+)?|90(?:\.0+)?))\s*,\s*"
+            r"([-+]?(?:180(?:\.0+)?|(?:1[0-7]\d|[1-9]?\d)(?:\.\d+)?))(?!\d)"
         )
         return re.findall(pattern, text)
 
-    def find_long_strings(self, text):
+    def find_long_strings(self, text: str) -> list[str]:
         """Return a list of long alphanumeric strings (20+ chars) found in the text."""
-        pattern = r'\b[a-zA-Z0-9_.-]{20,}\b'
+        pattern = r"\b[a-zA-Z0-9_.-]{20,}\b"
         return re.findall(pattern, text)
+
 
 # Example usage
 if __name__ == "__main__":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pre-commit
+ruff
+mypy


### PR DESCRIPTION
## Summary
- annotate all regex helper methods with explicit type hints
- add pre-commit config using ruff and mypy
- list ruff, mypy, and pre-commit as development requirements

## Testing
- `ruff format OSINT_REGEX.py`
- `ruff check OSINT_REGEX.py`
- `mypy OSINT_REGEX.py`
- `pre-commit run --files OSINT_REGEX.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db23946cc832480b0e94c6e0bb624