### PR TITLE
Add packaging metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "osint-regex"
+version = "0.1.0"
+description = "Regular expression helpers for OSINT tasks."
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = []
+urls = {"Homepage" = "https://github.com/OpenAI/OSINT_REGEX"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[options]
+py_modules = OSINT_REGEX


### PR DESCRIPTION
## Summary
- add pyproject metadata for build-system and project info
- configure setuptools to include OSINT_REGEX module

## Testing
- `pip install .` *(fails: Could not find a version that satisfies setuptools due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689db2322e6883249d6b49cb1900e7f4